### PR TITLE
tabular split only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # UniFrac implememtation in Rust
 
 This is an example repo to show how to compute the [UniFrac](https://en.wikipedia.org/wiki/UniFrac) distance between a pair of samples containing taxa. 
-It uses the [phylotree](https://github.com/lucblassel/phylotree-rs) crate to parse the tree file and feature-sample table (OTU table for example) and then compute the unifrac distance.
+It uses the [phylotree](https://github.com/lucblassel/phylotree-rs) crate to parse the tree file and feature-sample table (OTU table for example) and then compute the unweighted unifrac distance. This is the example implementation, not heavily optimized. 
+
+This is the orignal unweighted UniFrac, which is normalized by tree size for each pair of samples. That is the tree is trimmed first to include features in either of the sample or both but remove features that are not there for any of the samples. This unweighted is not a metric distance since the total space for each pair of samples is different. 
 
 ## Install
 ```bash

--- a/src/io.rs
+++ b/src/io.rs
@@ -19,7 +19,7 @@ pub fn read_sample_table(filename: &str) -> Result<(Vec<String>, Vec<String>, Ve
 
     // First line: parse sample names
     let header = lines.next().context("No header in table")??;
-    let mut hdr_split = header.split_whitespace();
+    let mut hdr_split = header.split('\t');
     hdr_split.next(); // ignore the first element in the header line
     let sample_names: Vec<String> = hdr_split.map(|s| s.to_string()).collect();
 
@@ -28,7 +28,7 @@ pub fn read_sample_table(filename: &str) -> Result<(Vec<String>, Vec<String>, Ve
 
     for line in lines {
         let line = line?;
-        let mut parts = line.split_whitespace();
+        let mut parts = line.split('\t');
         let taxon = parts.next().context("Taxon missing in a line")?.to_string();
         taxa_order.push(taxon);
         let values: Vec<f64> = parts


### PR DESCRIPTION
only allow tabular split, no space splitter, the #OTU ID one, we do not need to change it. Please merge if you find it useful. 

Thanks,
Jianshu